### PR TITLE
Install Fluence dependencies into public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Fluence dependencies
+public/avm.wasm
+public/marine-js.wasm
+public/marine-js.web.js

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
+    "postinstall": "copy-marine public",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
Starting from  v0.23.0 FluenceJS requires web server to serve AVM and MarineJS wasm files as well as the background marine runner script. This PR fixes the issue of non-working application by adding script which installs necessary dependencies. 